### PR TITLE
docs: add Related Resources section (Helldivers 2 Guides companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You can check the server API [here](./server_api_6.md)
 
 - Helldivers2 Stratagem Database [HD2CFS-Database](https://github.com/WisteFinch/HD2CFS-Database)
 - Helldivers Stratagem Database [HD2CFS-Database_HD](https://github.com/WisteFinch/HD2CFS-Database_HD)
+- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.
 
 ## Libs used
 


### PR DESCRIPTION
Thanks for the phone stratagem caller — players often want a guide hub alongside quick-input tools.

This PR adds a single link to the existing Related/Resources section pointing to a companion player-facing guide site:

- [Helldivers 2 Guides](https://hd2guides.com/) — Helldivers 2 stratagem tier lists, warbond guides, mission strategies, and loadout builds.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `append_to:## Links`.)_